### PR TITLE
gitignore: Ignore entire Android Studio project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+/.idea/
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
This project repo doesn't have an Android Studio project in it, so just ignore the entire project directory to avoid accidentally committing it.