### PR TITLE
HomeActivity: Request non-root shell from libsu

### DIFF
--- a/app/src/main/java/com/android/benchmark/app/HomeActivity.java
+++ b/app/src/main/java/com/android/benchmark/app/HomeActivity.java
@@ -53,7 +53,7 @@ public class HomeActivity extends AppCompatActivity implements Button.OnClickLis
         /* Shell.Config methods shall be called before any shell is created
          * This is the why in this example we call it in a static block
          * The followings are some examples, check Javadoc for more details */
-        Shell.Config.setFlags(Shell.FLAG_REDIRECT_STDERR);
+        Shell.Config.setFlags(Shell.FLAG_REDIRECT_STDERR | Shell.FLAG_NON_ROOT_SHELL);
         Shell.Config.setTimeout(10);
     }
 


### PR DESCRIPTION
There's no need to request a root shell just to run `uname -a`, which doesn't require root privileges. It blocks the upload process when the user is running the app for the first time and creates a potential security risk for no reason.